### PR TITLE
Add test to check what happens if we try to set unused XER bits

### DIFF
--- a/cputest/mtspr.cpp
+++ b/cputest/mtspr.cpp
@@ -2,20 +2,39 @@
 #include <wiiuse/wpad.h>
 #include "test.h"
 
-// Check what the PowerPC does if we set bits that we are not supposed to set.
+// Check what the Broadway does if we set reserved bits in the graphics quantization registers. The
+// CPU manual marks these as zero, but this isn't actually true.
 // Some games do this (e.g. Dirt 2) and rely on correct emulation behavior.
-static void UnusedBitsTest()
+static void GQRUnusedBitsTest()
 {
 	START_TEST();
 	uint32_t output;
-	uint32_t expected = 0x80048004U;
+	// based on hwtest on Wii
+	uint32_t expected = 0xFFFFFFFF;
 	asm(
-		"lis   %0, 32773;"
-		"subi  %0, %0, 32764;"
+		"li   %0, -1;"
 		"mtspr 914, %0;"
 		"mfspr %0, 914;"
 		: "=r"(output)
-	);
+		);
+
+	DO_TEST(output == expected, "got %x, expected %x", output, expected);
+	END_TEST();
+}
+
+// Check what the Broadway does if we set reserved bits in the XER (fixed-point exception) register.
+static void XERUnusedBitsTest()
+{
+	START_TEST();
+	uint32_t output;
+	// based on hwtest on Wii
+	uint32_t expected = 0xE000FF7F;
+	asm(
+		"li   %0, -1;"
+		"mtspr 1, %0;"
+		"mfspr %0, 1;"
+		: "=r"(output)
+		);
 
 	DO_TEST(output == expected, "got %x, expected %x", output, expected);
 	END_TEST();
@@ -26,7 +45,8 @@ int main()
 	network_init();
 	WPAD_Init();
 
-	UnusedBitsTest();
+	GQRUnusedBitsTest();
+	XERUnusedBitsTest();
 
 	network_printf("Shutting down...\n");
 	network_shutdown();


### PR DESCRIPTION
input: 0xFFFFFFFF
output: 0xE000FF7F

what the heck, broadway
