### PR TITLE
Fix and extend frsp test

### DIFF
--- a/cputest/fctiwz.cpp
+++ b/cputest/fctiwz.cpp
@@ -26,7 +26,7 @@ static void FctiwzTest()
     u64 input = values[i][0];
     u64 expected = values[i][1];
     u64 result = 0;
-    asm("fctiwz %0, %1" : "=f"(result) : "f"(input));
+    asm("fctiwz %0, %1" : "=d"(result) : "d"(input));
     DO_TEST(result == expected, "fctiwz(0x{:016x}):\n"
                                 "     got 0x{:016x}\n"
                                 "expected 0x{:016x}",

--- a/cputest/frsp.cpp
+++ b/cputest/frsp.cpp
@@ -30,7 +30,7 @@ static void FrspTest()
     u64 input = values[i][0];
     u64 expected = values[i][1];
     u64 result = 0;
-    asm("frsp %0, %1" : "=f"(result) : "f"(input));
+    asm("frsp %0, %1" : "=d"(result) : "d"(input));
     DO_TEST(result == expected, "frsp(0x{:016x}, NI={}):\n"
                                 "     got 0x{:016x}\n"
                                 "expected 0x{:016x}",

--- a/cputest/frsp.cpp
+++ b/cputest/frsp.cpp
@@ -15,9 +15,11 @@ static void FrspTest()
       {0x000fffffffffffff, 0x0000000000000000, 0b000},  // largest double subnormal
       {0x3690000000000000, 0x0000000000000000, 0b000},  // largest number rounded to zero
       {0x3690000000000001, 0x36a0000000000000, 0b000},  // smallest positive single subnormal
+      {0x380fffffe0000001, 0x0000000000000000, 0b110},  // boundary of architecture-dependent behavior in non-IEEE mode
       {0x380ffffff0000000, 0x0000000000000000, 0b100},  // boundary of architecture-dependent behavior in non-IEEE mode
       {0x380fffffffffffff, 0x0000000000000000, 0b100},  // largest single subnormal
       {0x3810000000000000, 0x3810000000000000, 0b100},  // smallest positive single normal
+      {0xb80fffffe0000001, 0x8000000000000000, 0b111},  // boundary of architecture-dependent behavior in non-IEEE mode
       {0xb80ffffff0000000, 0x8000000000000000, 0b100},  // boundary of architecture-dependent behavior in non-IEEE mode
       {0xb80fffffffffffff, 0x8000000000000000, 0b100},  // smallest single subnormal
       {0xb810000000000000, 0xb810000000000000, 0b100},  // largest negative single normal
@@ -35,10 +37,10 @@ static void FrspTest()
     u64 expected = values[i][1];
     u64 result = 0;
     asm("frsp %0, %1" : "=d"(result) : "d"(input));
-    DO_TEST(result == expected, "frsp(0x{:016x}, NI={}):\n"
+    DO_TEST(result == expected, "frsp(0x{:016x}, NI={}, RN={}):\n"
                                 "     got 0x{:016x}\n"
                                 "expected 0x{:016x}",
-            input, values[i][2] >> 2, result, expected);
+            input, values[i][2] >> 2, values[i][2] & 0b11, result, expected);
   }
   END_TEST();
 }

--- a/cputest/frsp.cpp
+++ b/cputest/frsp.cpp
@@ -19,7 +19,7 @@ static void FrspTest()
       {0x3810000000000000, 0x3810000000000000, 0b100},  // smallest positive single normal
       {0x7ff0000000000000, 0x7ff0000000000000, 0b000},  // +infinity
       {0xfff0000000000000, 0xfff0000000000000, 0b000},  // -infinity
-      {0xfff7ffffffffffff, 0xfff7ffffe0000000, 0b000},  // a SNaN
+      {0xfff7ffffffffffff, 0xffffffffe0000000, 0b000},  // a SNaN
       {0xffffffffffffffff, 0xffffffffe0000000, 0b000},  // a QNaN
   };
   for (size_t i = 0; i < sizeof(values) / sizeof(values[0]); i++)

--- a/cputest/frsp.cpp
+++ b/cputest/frsp.cpp
@@ -15,8 +15,12 @@ static void FrspTest()
       {0x000fffffffffffff, 0x0000000000000000, 0b000},  // largest double subnormal
       {0x3690000000000000, 0x0000000000000000, 0b000},  // largest number rounded to zero
       {0x3690000000000001, 0x36a0000000000000, 0b000},  // smallest positive single subnormal
+      {0x380ffffff0000000, 0x0000000000000000, 0b100},  // boundary of architecture-dependent behavior in non-IEEE mode
       {0x380fffffffffffff, 0x0000000000000000, 0b100},  // largest single subnormal
       {0x3810000000000000, 0x3810000000000000, 0b100},  // smallest positive single normal
+      {0xb80ffffff0000000, 0x8000000000000000, 0b100},  // boundary of architecture-dependent behavior in non-IEEE mode
+      {0xb80fffffffffffff, 0x8000000000000000, 0b100},  // smallest single subnormal
+      {0xb810000000000000, 0xb810000000000000, 0b100},  // largest negative single normal
       {0x7ff0000000000000, 0x7ff0000000000000, 0b000},  // +infinity
       {0xfff0000000000000, 0xfff0000000000000, 0b000},  // -infinity
       {0xfff7ffffffffffff, 0xffffffffe0000000, 0b000},  // a SNaN


### PR DESCRIPTION
It's been a while so I'm not sure why I didn't notice this. The SNaN needs to turn into a QNaN.

All subtests succeed on real hardware. 0x380fffffffffffff -> 0x0000000000000000 currently fails in Dolphin.
