### PR TITLE
common: Fix build by modernizing CommonTypes and add size_t

### DIFF
--- a/common/CommonTypes.h
+++ b/common/CommonTypes.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 using u8 = std::uint8_t;
@@ -19,3 +20,5 @@ using s8 = std::int8_t;
 using s16 = std::int16_t;
 using s32 = std::int32_t;
 using s64 = std::int64_t;
+
+using size_t = std::size_t;

--- a/common/CommonTypes.h
+++ b/common/CommonTypes.h
@@ -10,37 +10,12 @@
 
 #include <cstdint>
 
-#ifdef _WIN32
+using u8 = std::uint8_t;
+using u16 = std::uint16_t;
+using u32 = std::uint32_t;
+using u64 = std::uint64_t;
 
-#include <tchar.h>
-
-typedef uint8_t u8;
-typedef uint16_t u16;
-typedef uint32_t u32;
-typedef uint64_t u64;
-
-typedef int8_t s8;
-typedef int16_t s16;
-typedef int32_t s32;
-typedef int64_t s64;
-
-#else
-
-//#ifndef GEKKO
-
-typedef uint8_t u8;
-typedef uint16_t u16;
-typedef uint32_t u32;
-typedef uint64_t u64;
-
-typedef int8_t s8;
-typedef int16_t s16;
-typedef int32_t s32;
-typedef int64_t s64;
-
-//#endif
-// For using windows lock code
-#define TCHAR char
-#define LONG int
-
-#endif  // _WIN32
+using s8 = std::int8_t;
+using s16 = std::int16_t;
+using s32 = std::int32_t;
+using s64 = std::int64_t;


### PR DESCRIPTION
It's convenient not to have to explicitly qualify std::size_t,
and some of our tests use size_t :)

Fixes building with GCC 10.