### PR TITLE
Re-delete bitfield's copy-assignment operator

### DIFF
--- a/common/BitField.h
+++ b/common/BitField.h
@@ -131,9 +131,13 @@ public:
   // so that we can use this within unions
   constexpr BitField() = default;
 
-  // Warning!  This copies ALL storage bits, not just the bits represented by this bitfield.
-  // This exists so that unions can be copyable.
-  BitField& operator=(const BitField&) = default;
+  // We explicitly delete the copy assignment operator here, because the
+  // default copy assignment would copy the full storage value, rather than
+  // just the bits relevant to this particular bit field.
+  // Ideally, we would just implement the copy assignment to copy only the
+  // relevant bits, but we're prevented from doing that because the savestate
+  // code expects that this class is trivially copyable.
+  BitField& operator=(const BitField&) = delete;
 
   BitField& operator=(T val)
   {

--- a/common/BitField.h
+++ b/common/BitField.h
@@ -130,6 +130,8 @@ public:
   // Force default constructor to be created
   // so that we can use this within unions
   constexpr BitField() = default;
+  constexpr BitField(const BitField&) = default;
+  constexpr BitField(BitField&&) = default;
 
   // We explicitly delete the copy assignment operator here, because the
   // default copy assignment would copy the full storage value, rather than
@@ -138,6 +140,13 @@ public:
   // relevant bits, but we're prevented from doing that because the savestate
   // code expects that this class is trivially copyable.
   BitField& operator=(const BitField&) = delete;
+  // However, to allow assignment of unions returned by CGXDefault, we allow
+  // the use of the move assignment operator. This default implementation
+  // still copies all bits rather than just the bits relevant to this bit field,
+  // but this behavior is desirable when copying unions. Note that although
+  // the right-hand operand is not const (which is required for default to work),
+  // it is not modified.
+  constexpr BitField& operator=(BitField&&) = default;
 
   BitField& operator=(T val)
   {
@@ -233,6 +242,8 @@ public:
   // Force default constructor to be created
   // so that we can use this within unions
   constexpr BitFieldArray() = default;
+  constexpr BitFieldArray(const BitFieldArray&) = default;
+  constexpr BitFieldArray(BitFieldArray&&) = default;
 
   // We explicitly delete the copy assignment operator here, because the
   // default copy assignment would copy the full storage value, rather than
@@ -241,6 +252,13 @@ public:
   // relevant bits, but we're prevented from doing that because the savestate
   // code expects that this class is trivially copyable.
   BitFieldArray& operator=(const BitFieldArray&) = delete;
+  // However, to allow assignment of unions returned by CGXDefault, we allow
+  // the use of the move assignment operator. This default implementation
+  // still copies all bits rather than just the bits relevant to this bit field,
+  // but this behavior is desirable when copying unions. Note that although
+  // the right-hand operand is not const (which is required for default to work),
+  // it is not modified.
+  constexpr BitFieldArray& operator=(BitFieldArray&&) = default;
 
 public:
   constexpr bool IsSigned() const { return std::is_signed<T>(); }

--- a/gxtest/cgx_defaults.h
+++ b/gxtest/cgx_defaults.h
@@ -9,13 +9,13 @@
 #include "gxtest/XFMemory.h"
 
 template <typename T>
-static T CGXDefault();
+static T CGXDefault() = delete;
 
 template <typename T>
-static T CGXDefault(int);
+static T CGXDefault(int) = delete;
 
 template <typename T>
-static T CGXDefault(int, bool);
+static T CGXDefault(int, bool) = delete;
 
 template <>
 GenMode CGXDefault<GenMode>()

--- a/gxtest/util.cpp
+++ b/gxtest/util.cpp
@@ -394,7 +394,7 @@ Vec4<int> GetTevOutput(const GenMode& genmode, const TevStageCombiner::ColorComb
   // Uses three additional TEV stages which shift the previous result
   // three bits to the right. This is necessary to read off the 5 upper bits,
   // 3 of which got masked off when writing to the EFB in the first pass.
-  gm = genmode;
+  gm.hex = genmode.hex;
   gm.numtevstages = previous_stage + 3;  // three additional stages
   CGX_LOAD_BP_REG(gm.hex);
 


### PR DESCRIPTION
Now, the move-assignment operator is provided so that unions can be assigned to with the CGX defaults.

See https://github.com/dolphin-emu/hwtests/pull/46#discussion_r853849782.