### PR TITLE
CGX_DoEfbCopyTex: Use DCInvalidateRange instead of DCFlushRange

### DIFF
--- a/gxtest/cgx.cpp
+++ b/gxtest/cgx.cpp
@@ -165,7 +165,7 @@ void CGX_DoEfbCopyTex(u16 left, u16 top, u16 width, u16 height, u8 dest_format,
   reg.clamp_bottom = true;
   CGX_LOAD_BP_REG(reg.Hex);
 
-  DCFlushRange(dest, GX_GetTexBufferSize(width, height, GX_TF_RGBA8, GX_FALSE, 1));
+  DCInvalidateRange(dest, GX_GetTexBufferSize(width, height, GX_TF_RGBA8, GX_FALSE, 1));
 }
 
 void CGX_DoEfbCopyXfb(u16 left, u16 top, u16 width, u16 src_height, u16 dst_height, void* dest,


### PR DESCRIPTION
See https://github.com/dolphin-emu/hwtests/pull/44#discussion_r856676264.