### PR TITLE
cputest_ni: Add tests for subnormals that get rounded to normals

### DIFF
--- a/cputest/ni.cpp
+++ b/cputest/ni.cpp
@@ -12,6 +12,12 @@ static const double product = Common::BitCast<double>(0x3ccfffffffffffffULL);
 static const double smallest_normal = Common::BitCast<double>(0x0010000000000000ULL);
 static const double divisor = Common::BitCast<double>(0x4330000000000000ULL);
 
+static const double one_minus_ulp = Common::BitCast<double>(0x3fefffffffffffffULL);
+
+static const float zero_single = Common::BitCast<float>(0);
+static const float smallest_normal_single = Common::BitCast<float>(0x00800000);
+static const float one_minus_ulp_single = Common::BitCast<float>(0x3f7fffff);
+
 // Test of the Non-IEEE bit in FPSCR
 static void NiTest()
 {
@@ -49,6 +55,22 @@ static void NiTest()
             "     got 0x{:016x}\n"
             "expected 0x{:016x}",
             ni, div_result, div_expected);
+
+    const u64 mul2_expected = Common::BitCast<u64>(outputs_expected_flushed ? zero : smallest_normal);
+    const u64 mul2_result = Common::BitCast<u64>(smallest_normal * one_minus_ulp);
+    DO_TEST(mul2_result == mul2_expected,
+            "Multiply smallest normal by 1 minus ULP (NI={}):\n"
+            "     got 0x{:016x}\n"
+            "expected 0x{:016x}",
+            ni, mul2_result, mul2_expected);
+
+    const u32 mul3_expected = Common::BitCast<u32>(outputs_expected_flushed ? zero_single : smallest_normal_single);
+    const u32 mul3_result = Common::BitCast<u32>(smallest_normal_single * one_minus_ulp_single);
+    DO_TEST(mul3_result == mul3_expected,
+            "Multiply smallest normal single by 1 minus ULP (NI={}):\n"
+            "     got 0x{:08x}\n"
+            "expected 0x{:08x}",
+            ni, mul3_result, mul3_expected);
   }
 
   END_TEST();


### PR DESCRIPTION
I wrote these two tests because I wanted to test if the behavior I implemented in https://github.com/dolphin-emu/dolphin/pull/10959 should affect the results of arithmetic operations in addition to frsp. It turned out that Dolphin was already correctly emulating these two tests (I frankly don't understand how in the float case), but I figured I would submit the tests regardless. If nothing else, it's good for documenting what the real hardware is doing.