### PR TITLE
Fix -Wsign-compare warnings

### DIFF
--- a/cputest/rlw.cpp
+++ b/cputest/rlw.cpp
@@ -33,7 +33,7 @@ static void rlwimixTest()
 #define RLWIMIX_TEST(sh, mb, me)                                                                   \
   do                                                                                               \
   {                                                                                                \
-    for (int i = 0; i < (sizeof(values) / sizeof(values[0])); ++i)                                 \
+    for (size_t i = 0; i < (sizeof(values) / sizeof(values[0])); ++i)                                 \
     {                                                                                              \
       u32 mask = GetHelperMask(mb, me);                                                            \
       u32 computed_result = (values[i][0] & ~mask) | (_rotl(values[i][1], sh) & mask);             \
@@ -88,7 +88,7 @@ static void rlwinmxTest()
 #define RLWINMX_TEST(sh, mb, me)                                                                   \
   do                                                                                               \
   {                                                                                                \
-    for (int i = 0; i < (sizeof(values) / sizeof(values[0])); ++i)                                 \
+    for (size_t i = 0; i < (sizeof(values) / sizeof(values[0])); ++i)                                 \
     {                                                                                              \
       u32 mask = GetHelperMask(mb, me);                                                            \
       u32 computed_result = _rotl(values[i], sh) & mask;                                           \
@@ -144,7 +144,7 @@ static void rlwnmxTest()
   do                                                                                               \
   {                                                                                                \
     for (int sh = 0; sh < 32; ++sh)                                                                \
-      for (int i = 0; i < (sizeof(values) / sizeof(values[0])); ++i)                               \
+      for (size_t i = 0; i < (sizeof(values) / sizeof(values[0])); ++i)                               \
       {                                                                                            \
         u32 mask = GetHelperMask(mb, me);                                                          \
         u32 computed_result = _rotl(values[i], sh & 0x1F) & mask;                                  \


### PR DESCRIPTION
Note that building with libogc v2.7.0 or later is currently broken due to conflicts with preprocessor defines added in https://github.com/devkitPro/libogc/commit/f1c3747a5aa8580a9fdb581b8e3275df7a17aa11.